### PR TITLE
docs: Added expected file structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Pre-compiled binaries are available in the
    folder. Create the folder if it does not already exist
 
 ### Linux
-1. Copy `mpv_websocket` into your
+1. Copy the `mpv_websocket` binary file into your
    [~/.config/mpv](https://mpv.io/manual/stable/#files) folder. Create the
    folder if it does not already exist
 2. Copy [mpv.conf](mpv/mpv.conf) into your
@@ -71,7 +71,7 @@ Pre-compiled binaries are available in the
 ### Mac
 Note, I do not have a Mac and cannot test it, but it should be the same as Linux
 
-1. Copy `mpv_websocket` into your
+1. Copy the `mpv_websocket` binary file into your
    [~/.config/mpv](https://mpv.io/manual/stable/#files) folder. Create the
    folder if it does not already exist
 2. Copy [mpv.conf](mpv/mpv.conf) into your
@@ -81,6 +81,20 @@ Note, I do not have a Mac and cannot test it, but it should be the same as Linux
    into your
    [~/.config/mpv/scripts](https://mpv.io/manual/stable/#files) folder.
    Create the folder if it does not already exist
+
+## Troubleshooting
+If mpv_websocket doesn't seem to work:
+-   Ensure you are using the
+    [latest version of mpv](https://mpv.io/installation/).
+
+    Note that for Linux, some package managers may distribute old versions
+    of mpv. According to mpv's official documentation, it is recommended that
+    you compile mpv using
+    [mpv-build](https://github.com/mpv-player/mpv-build/),
+    or use third party libraries instead.
+
+-   Try [manually building](#build) the binary instead of using the
+    pre-compiled binary.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,18 @@ Pre-compiled binaries are available in the
    [%appdata%\mpv\scripts](https://mpv.io/manual/stable/#files-on-windows)
    folder. Create the folder if it does not already exist
 
+<details><summary>Expected file structure</summary>
+
+```
+%appdata%\mpv
+├── mpv.conf
+├── mpv_websocket.exe
+└── scripts
+    └── run_websocket_server_windows.lua
+```
+
+</details>
+
 ### Linux
 1. Copy the
    [mpv_websocket](https://github.com/kuroahna/mpv_websocket/releases/download/0.1.0/x86_64-unknown-linux-gnu.zip)
@@ -78,6 +90,19 @@ Pre-compiled binaries are available in the
    into your
    [~/.config/mpv/scripts](https://mpv.io/manual/stable/#files) folder.
    Create the folder if it does not already exist
+
+<details><summary>Expected file structure</summary>
+
+```
+~/.config/mpv/
+├── mpv.conf
+├── mpv_websocket
+└── scripts
+    └── run_websocket_server_linux.lua
+```
+
+</details>
+
 
 ### Mac
 Note, I do not have a Mac and cannot test it, but it should be the same as Linux
@@ -94,6 +119,18 @@ Note, I do not have a Mac and cannot test it, but it should be the same as Linux
    into your
    [~/.config/mpv/scripts](https://mpv.io/manual/stable/#files) folder.
    Create the folder if it does not already exist
+
+<details><summary>Expected file structure</summary>
+
+```
+~/.config/mpv/
+├── mpv.conf
+├── mpv_websocket
+└── scripts
+    └── run_websocket_server_linux.lua
+```
+
+</details>
 
 ## Troubleshooting
 If after following the [Installation](#install) steps and mpv_websocket doesn't


### PR DESCRIPTION
It seems like a decent amount of confusion is caused simply by where the files are, so this PR adds a few dropdowns to show the expected file structure (as a tree). See the rendered result [here](https://github.com/Aquafina-water-bottle/mpv_websocket#install).