### PR TITLE
feat: talk-tts prints and speaks the subtitles.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,10 @@ name = "mpv_websocket"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+talk-tts = ["tts"]
+
+
 [dependencies]
 clap = { version = "4.1.8", features = ["derive"] }
 parity-tokio-ipc = "0.9.0"
@@ -10,3 +14,4 @@ serde = { version = "1.0.155", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.94", default-features = false, features = ["std"] }
 tokio = { version = "1.26.0", default-features = false, features = ["macros", "rt-multi-thread", "io-util"] }
 ws = { version = "0.9.2", default-features = false }
+tts = { version = "0.25.6", optional = true }


### PR DESCRIPTION
This works pretty good.  I changed the data to be optional and I think the PartialEq came as a result.

I have other code that checks and waits for the pipe to exist and some other than prepends the \\.\\pipe\\ as mpv does.  I can share that too...