### PR TITLE
Allow the user to override the server bind address

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ struct Args {
     #[arg(short('a'), long, default_value_t = IpAddr::V4(Ipv4Addr::UNSPECIFIED))]
     websocket_server_bind_address: IpAddr,
 
-    #[arg(short, long, default_value_t = 6677)]
+    #[arg(short('p'), visible_short_alias('w'), long, default_value_t = 6677)]
     websocket_server_port: u16,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::net::SocketAddr;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 
 use clap::Parser;
@@ -11,6 +11,9 @@ struct Args {
     #[arg(short, long)]
     mpvsocket_path: PathBuf,
 
+    #[arg(short('a'), long, default_value_t = IpAddr::V4(Ipv4Addr::UNSPECIFIED))]
+    websocket_server_bind_address: IpAddr,
+
     #[arg(short, long, default_value_t = 6677)]
     websocket_server_port: u16,
 }
@@ -19,10 +22,10 @@ struct Args {
 async fn main() {
     let args = Args::parse();
 
-    let server = websocket::Server::new(SocketAddr::from((
-        [0, 0, 0, 0],
+    let server = websocket::Server::new(SocketAddr::new(
+        args.websocket_server_bind_address,
         args.websocket_server_port,
-    )))
+    ))
     .start();
 
     mpv::Client::new(args.mpvsocket_path)


### PR DESCRIPTION
~97021dd already changed the docs but didn't adjust the code.~

edit: Allow the user to override the server bind address. Also adjust the short argument for the port from `-w` to `-p` which makes more sense.